### PR TITLE
Add stage descriptions for `parsing expressions` extension.

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -27,6 +27,7 @@ languages:
   - slug: "go"
   - slug: "python"
   - slug: "rust"
+  - slug: "kotlin"
 
 marketing:
   difficulty: hard
@@ -739,17 +740,17 @@ stages:
       from chapter 6, [Parsing Expressions](https://craftinginterpreters.com/parsing-expressions.html).
 
       ---
-      In this stage you'll implement basic support for the `parse` command, and use the `parse` command to parse a list of scanned tokens from your scanner. 
+      In this stage you'll implement basic support for the `parse` command, and use the `parse` command to parse a list of scanned tokens from your scanner.
       In this stage, you will implement parsing of boolean values and the `nil` literal.
 
       ### The `parse` command
 
-      // TODO first stage shouldn't be hard      
+      // TODO first stage shouldn't be hard
       // TODO `parse` command and `parsing` together ? Break it into 2 stages ?
       // TODO introduce the concept of AST here ? How to tell them to implement the AST printer ?
       // TODO tell them that this part is introduced at the end of the book.
       // TODO Can't deep link to sections, what is the point then ? Everything will have the same link.
-      // TODO link to 6.2 or 6.2.1 ? 6.2 makes more sense to me. 
+      // TODO link to 6.2 or 6.2.1 ? 6.2 makes more sense to me.
 
       The `parse` command parses a given list of tokens from the Scanner, and prints out the ast representation to stdout. We'll use this for testing
       all stages in the [Parsing Expressions](https://craftinginterpreters.com/parsing-expressions.html) extension.
@@ -902,7 +903,7 @@ stages:
 
       The tester will assert that the stdout of your program matches the format above.
 
-      Remember, in this stage, unmatched parentheses are invalid. So, if you encounter something like `("foo"` it is a `ParseError`. 
+      Remember, in this stage, unmatched parentheses are invalid. So, if you encounter something like `("foo"` it is a `ParseError`.
       In this extension we won't check the exact error message you print to stderr. We will just assert that the exit code is 65. So, you can print any error message you want, and also use the stderr stream for your own debug logs.
 
       ### Notes

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -946,3 +946,112 @@ stages:
       - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/parse.lox)
     marketing_md: |-
       In this stage, you'll implement support for parsing unary operators `!` and `-`.
+
+  - slug: "wa9"
+    primary_extension_slug: "parser"
+    name: "Parsing: Multiplicative algebraic operators"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for parsing additive algebraic operators. You need to just support the multiplication operator `*` & the division operator `/`.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 6.2: Recursive Descent Parsing](https://craftinginterpreters.com/parsing-expressions.html#recursive-descent-parsing).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain multiplicative algebraic operators, combined with previously introduced tokens.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      16 * 38 / 58
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh parse test.lox
+      (/ (* 16.0 38.0) 58.0)
+      ```
+
+      The tester will assert that the stdout of your program matches the format above. Make sure to respect the operator precedence.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/parse.lox)
+    marketing_md: |-
+      In this stage, you'll implement support for parsing multiplicative algebraic operators `*` and `/`.
+
+  - slug: "yf2"
+    primary_extension_slug: "parser"
+    name: "Parsing: Additive algebraic operators"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for parsing additive algebraic operators. You need to just support the addition operator `+` & the subtraction operator `-`.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 6.2: Recursive Descent Parsing](https://craftinginterpreters.com/parsing-expressions.html#recursive-descent-parsing).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain additive algebraic operators, combined with previously introduced tokens.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      52 + 80 - 94
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh parse test.lox
+      (- (+ 52.0 80.0) 94.0)
+      ```
+
+      The tester will assert that the stdout of your program matches the format above. Make sure to respect the operator precedence.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/parse.lox)
+    marketing_md: |-
+      In this stage, you'll implement support for parsing additive algebraic operators `+` and `-`.
+
+  - slug: "uh4"
+    primary_extension_slug: "parser"
+    name: "Parsing: Comparison operators"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for parsing comparison operators. You need to support the four comparison operators `>`, `<`, `>=` & `<=`.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 6.2: Recursive Descent Parsing](https://craftinginterpreters.com/parsing-expressions.html#recursive-descent-parsing).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain comparison operators, combined with previously introduced tokens.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      83 < 99 < 115
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh parse test.lox
+      (< (< 83.0 99.0) 115.0)
+      ```
+
+      The tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/parse.lox)
+    marketing_md: |-
+      In this stage, you'll implement support for parsing comparison operators `>`, `<`, `>=` & `<=`.
+

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -27,7 +27,6 @@ languages:
   - slug: "go"
   - slug: "python"
   - slug: "rust"
-  - slug: "kotlin"
 
 marketing:
   difficulty: hard
@@ -47,6 +46,13 @@ marketing:
       text: |-
         I think the instant feedback right there in the git push is really cool.
         Didn't even know that was possible!
+
+
+extensions:
+  - slug: "parser"
+    name: "Parsing Expressions"
+    description_markdown: |
+      In this challenge extension you'll add the ability to parse expressions to your interpreter implementation.
 
 stages:
   - slug: "ry8"
@@ -719,3 +725,224 @@ stages:
       - When scanning for tokens, it's valid to have "unbalanced" parentheses or braces. When we get to parsing expressions in later stages, these cases will be highlighted as errors.
     marketing_md: |-
       In this stage, you'll implement support for scanning reserved words.
+
+  - slug: "sc2"
+    primary_extension_slug: "parser"
+    name: "Parsing: Booleans & Nil"
+    difficulty: hard
+    description_md: |-
+      Before starting this stage, make sure you've read the following chapter from the "A Tree-Walk Interpreter" section of the book:
+
+      - [Representing Code](https://craftinginterpreters.com/representing-code.html) (chapter 5)
+
+      These chapter won't be directly tested in this extension, but the code covered in this chapter from the book will be required. This extension will start
+      from chapter 6, [Parsing Expressions](https://craftinginterpreters.com/parsing-expressions.html).
+
+      ---
+      In this stage you'll implement basic support for the `parse` command, and use the `parse` command to parse a list of scanned tokens from your scanner. 
+      In this stage, you will implement parsing of boolean values and the `nil` literal.
+
+      ### The `parse` command
+
+      // TODO first stage shouldn't be hard      
+      // TODO `parse` command and `parsing` together ? Break it into 2 stages ?
+      // TODO introduce the concept of AST here ? How to tell them to implement the AST printer ?
+      // TODO tell them that this part is introduced at the end of the book.
+      // TODO Can't deep link to sections, what is the point then ? Everything will have the same link.
+      // TODO link to 6.2 or 6.2.1 ? 6.2 makes more sense to me. 
+
+      The `parse` command parses a given list of tokens from the Scanner, and prints out the ast representation to stdout. We'll use this for testing
+      all stages in the [Parsing Expressions](https://craftinginterpreters.com/parsing-expressions.html) extension.
+
+      If there's a file named `test.lox` with the following contents:
+
+      ```
+      (2 + 3);
+      ```
+
+      The `parse` command will return the following:
+
+      ```
+      $ ./your_program.sh parse test.lox
+      (group (+ 2.0 3.0))
+      ```
+
+      This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/parse.lox).
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 6.2: Recursive Descent Parsing](https://craftinginterpreters.com/parsing-expressions.html#recursive-descent-parsing).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain the boolean values `true` & `false`, and the `nil` literal.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      true
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh tokenize test.lox
+      true
+      ```
+
+      The tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/parse.lox)
+
+    marketing_md: |-
+      In this stage, you'll implement support for parsing binary values and the nil literal.
+
+
+  - slug: "ra8"
+    primary_extension_slug: "parser"
+    name: "Parsing: Number literals"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for parsing number literals.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 6.2: Recursive Descent Parsing](https://craftinginterpreters.com/parsing-expressions.html#recursive-descent-parsing).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain number literals, we include both ints and floats.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      42.47
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh parse test.lox
+      42.47
+      ```
+
+      The tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/parse.lox)
+    marketing_md: |-
+      In this stage, you'll implement support for parsing number literals.
+
+  - slug: "th5"
+    primary_extension_slug: "parser"
+    name: "Parsing: String literals"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for parsing string literals.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 6.2: Recursive Descent Parsing](https://craftinginterpreters.com/parsing-expressions.html#recursive-descent-parsing).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain string literals, it can contain whitespaces, and numbers too, but everything is inside double quotes.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      "foo hello"
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh parse test.lox
+      foo hello
+      ```
+
+      The tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/parse.lox)
+    marketing_md: |-
+      In this stage, you'll implement support for parsing string literals.
+
+  - slug: "xe6"
+    primary_extension_slug: "parser"
+    name: "Parsing: Parentheses"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for parsing parentheses.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 6.2: Recursive Descent Parsing](https://craftinginterpreters.com/parsing-expressions.html#recursive-descent-parsing).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain parentheses, combined with number literals, string literals and booleans.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      ("foo")
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh parse test.lox
+      (group foo)
+      ```
+
+      The tester will assert that the stdout of your program matches the format above.
+
+      Remember, in this stage, unmatched parentheses are invalid. So, if you encounter something like `("foo"` it is a `ParseError`. 
+      In this extension we won't check the exact error message you print to stderr. We will just assert that the exit code is 65. So, you can print any error message you want, and also use the stderr stream for your own debug logs.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/parse.lox)
+    marketing_md: |-
+      In this stage, you'll implement support for parsing parentheses.
+
+  - slug: "mq1"
+    primary_extension_slug: "parser"
+    name: "Parsing: Unary Operators"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for parsing unary operators. You need to just support the negation operator `-` & the logical not operator `!`.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 6.2: Recursive Descent Parsing](https://craftinginterpreters.com/parsing-expressions.html#recursive-descent-parsing).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain unary operators, combined with previously introduced tokens.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      !true
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh parse test.lox
+      (! true)
+      ```
+
+      The tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/parse.lox)
+    marketing_md: |-
+      In this stage, you'll implement support for parsing unary operators `!` and `-`.

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -48,7 +48,6 @@ marketing:
         I think the instant feedback right there in the git push is really cool.
         Didn't even know that was possible!
 
-
 extensions:
   - slug: "parsing-expressions"
     name: "Parsing Expressions"
@@ -732,47 +731,46 @@ stages:
     name: "Parsing: Booleans & Nil"
     difficulty: hard
     description_md: |-
-      Before starting this stage, make sure you've read the following chapter from the "A Tree-Walk Interpreter" section of the book:
+      In this stage you'll implement support for the `parse` command and handle parsing `true`, `false`, and `nil` literals.
 
-      - [Representing Code](https://craftinginterpreters.com/representing-code.html) (chapter 5)
+      ### Book reference
 
-      These chapter won't be directly tested in this extension, but the code covered in this chapter from the book will be required. This extension will start
-      from chapter 6, [Parsing Expressions](https://craftinginterpreters.com/parsing-expressions.html).
+      Before starting this stage, make sure you've read the [Representing Code](https://craftinginterpreters.com/representing-code.html) chapter (chapter 5). The
+      code covered in that chapter (`AstPrinter`) will be required to generate the output tested in this stage.
 
-      ---
-      In this stage you'll implement basic support for the `parse` command, and use the `parse` command to parse a list of scanned tokens from your scanner.
-      In this stage, you will implement parsing of boolean values and the `nil` literal.
+      The code for this stage is implemented in [Section 6.2: Recursive Descent Parsing](https://craftinginterpreters.com/parsing-expressions.html#recursive-descent-parsing).
 
       ### The `parse` command
 
-      // TODO first stage shouldn't be hard
-      // TODO `parse` command and `parsing` together ? Break it into 2 stages ?
-      // TODO introduce the concept of AST here ? How to tell them to implement the AST printer ?
-      // TODO tell them that this part is introduced at the end of the book.
-      // TODO Can't deep link to sections, what is the point then ? Everything will have the same link.
-      // TODO link to 6.2 or 6.2.1 ? 6.2 makes more sense to me.
+      In the previous stages, the tester used the `tokenize` command to test your scanner implementation. In this extension, the tester will need to test
+      your parser implementation, so it'll use a different command instead: `parse`.
 
-      The `parse` command parses a given list of tokens from the Scanner, and prints out the ast representation to stdout. We'll use this for testing
-      all stages in the [Parsing Expressions](https://craftinginterpreters.com/parsing-expressions.html) extension.
+      The `parse` command accepts a path to a file (`test.lox` for example) and prints out the AST representation of the file to stdout.
 
-      If there's a file named `test.lox` with the following contents:
+      For example, if `test.lox` contains the following:
 
       ```
-      (2 + 3);
+      2 + 3
       ```
 
       The `parse` command will return the following:
 
       ```
       $ ./your_program.sh parse test.lox
-      (group (+ 2.0 3.0))
+      (+ 2.0 3.0)
       ```
 
       This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/parse.lox).
 
-      ### Book reference
+      For the same file, here's what the output from `tokenize` would've been:
 
-      The code for this stage is implemented in [Section 6.2: Recursive Descent Parsing](https://craftinginterpreters.com/parsing-expressions.html#recursive-descent-parsing).
+      ```
+      $ ./your_program.sh tokenize test.lox
+      NUMBER 2.0 2.0
+      PLUS +
+      NUMBER 3.0 3.0
+      EOF  null
+      ```
 
       ### Tests
 
@@ -787,7 +785,7 @@ stages:
       The tester will run your program like this:
 
       ```
-      $ ./your_program.sh tokenize test.lox
+      $ ./your_program.sh parse test.lox
       true
       ```
 
@@ -796,10 +794,9 @@ stages:
       ### Notes
 
       - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/parse.lox)
-
+      <!-- TODO: Clarify how `nil` must be printed: `nil`/`null`? -->
     marketing_md: |-
       In this stage, you'll implement support for parsing binary values and the nil literal.
-
 
   - slug: "ra8"
     primary_extension_slug: "parsing-expressions"
@@ -855,14 +852,14 @@ stages:
       For example, if `test.lox` contains the following:
 
       ```
-      "foo hello"
+      "hello"
       ```
 
       The tester will run your program like this:
 
       ```
       $ ./your_program.sh parse test.lox
-      foo hello
+      hello
       ```
 
       The tester will assert that the stdout of your program matches the format above.
@@ -903,8 +900,20 @@ stages:
 
       The tester will assert that the stdout of your program matches the format above.
 
-      Remember, in this stage, unmatched parentheses are invalid. So, if you encounter something like `("foo"` it is a `ParseError`.
-      In this extension we won't check the exact error message you print to stderr. We will just assert that the exit code is 65. So, you can print any error message you want, and also use the stderr stream for your own debug logs.
+      The tester will also check whether your program exits with code 65 if there are unmatched parentheses. For example, if `test.lox` contains the following:
+
+      ```
+      ("foo
+      ```
+
+      The tester will run your program like this and assert that the exit code is 65:
+
+      ```
+      $ ./your_program.sh parse test.lox
+      Error: Unmatched parentheses.
+      ```
+
+      The exact error message will not be checked, the tester will only check that the program exits with code 65.
 
       ### Notes
 
@@ -917,7 +926,7 @@ stages:
     name: "Parsing: Unary Operators"
     difficulty: medium
     description_md: |-
-      In this stage, you'll add support for parsing unary operators. You need to just support the negation operator `-` & the logical not operator `!`.
+      In this stage, you'll add support for parsing the negation operator (`-`) & the logical not operator (`!`).
 
       ### Book reference
 
@@ -950,10 +959,10 @@ stages:
 
   - slug: "wa9"
     primary_extension_slug: "parsing-expressions"
-    name: "Parsing: Multiplicative algebraic operators"
+    name: "Parsing: Arithmetic operators (1/2)"
     difficulty: medium
     description_md: |-
-      In this stage, you'll add support for parsing additive algebraic operators. You need to just support the multiplication operator `*` & the division operator `/`.
+      In this stage, you'll add support for parsing the multiplication operator (`*`) & the division operator (`/`).
 
       ### Book reference
 
@@ -976,7 +985,7 @@ stages:
       (/ (* 16.0 38.0) 58.0)
       ```
 
-      The tester will assert that the stdout of your program matches the format above. Make sure to respect the operator precedence.
+      The tester will assert that the stdout of your program matches the format above. Make sure to handle operator precedence correctly (`*` has higher precedence than `/`).
 
       ### Notes
 
@@ -986,10 +995,10 @@ stages:
 
   - slug: "yf2"
     primary_extension_slug: "parsing-expressions"
-    name: "Parsing: Additive algebraic operators"
+    name: "Parsing: Arithmetic operators (2/2)"
     difficulty: medium
     description_md: |-
-      In this stage, you'll add support for parsing additive algebraic operators. You need to just support the addition operator `+` & the subtraction operator `-`.
+      In this stage, you'll add support for parsing the addition operator (`+`) & the subtraction operator (`-`).
 
       ### Book reference
 
@@ -1012,7 +1021,7 @@ stages:
       (- (+ 52.0 80.0) 94.0)
       ```
 
-      The tester will assert that the stdout of your program matches the format above. Make sure to respect the operator precedence.
+      The tester will assert that the stdout of your program matches the format above. Make sure to handle operator precedence correctly (`+` has higher precedence than `-`).
 
       ### Notes
 
@@ -1025,7 +1034,7 @@ stages:
     name: "Parsing: Comparison operators"
     difficulty: medium
     description_md: |-
-      In this stage, you'll add support for parsing comparison operators. You need to support the four comparison operators `>`, `<`, `>=` & `<=`.
+      In this stage, you'll add support for parsing comparison operators: `>`, `<`, `>=` & `<=`.
 
       ### Book reference
 
@@ -1128,4 +1137,3 @@ stages:
       - We won't check the exact error message on stderr just the proper exitCode will suffice.
     marketing_md: |-
       In this stage, you'll implement support for parsing syntax errors.
-

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -1055,3 +1055,76 @@ stages:
     marketing_md: |-
       In this stage, you'll implement support for parsing comparison operators `>`, `<`, `>=` & `<=`.
 
+  - slug: "ht8"
+    primary_extension_slug: "parser"
+    name: "Parsing: Equality operators"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for parsing equality operators. You need to support the two comparison operators `==` & `!=`.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 6.2: Recursive Descent Parsing](https://craftinginterpreters.com/parsing-expressions.html#recursive-descent-parsing).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain comparison operators, combined with previously introduced tokens.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      "baz" == "baz"
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh parse test.lox
+      (== baz baz)
+      ```
+
+      The tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/parse.lox)
+    marketing_md: |-
+      In this stage, you'll implement support for parsing equality operators `==` & `!=`.
+
+  - slug: "wz8"
+    primary_extension_slug: "parser"
+    name: "Parsing: Syntactic errors"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for handling syntax errors in the expression passed to you. We won't check the exact error message on stderr just the proper exitCode will suffice.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 6.3: Syntax Errors](https://craftinginterpreters.com/parsing-expressions.html#syntax-errors).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain syntax errors.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      (72 +)
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh parse test.lox
+      [line 1] Error at ')': Expect expression.
+      ```
+
+      The tester will assert that the exitCode is 65, if there was a syntax error in the expression.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/parse.lox)
+      - We won't check the exact error message on stderr just the proper exitCode will suffice.
+    marketing_md: |-
+      In this stage, you'll implement support for parsing syntax errors.
+

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -728,7 +728,7 @@ stages:
       In this stage, you'll implement support for scanning reserved words.
 
   - slug: "sc2"
-    primary_extension_slug: "parser"
+    primary_extension_slug: "parsing-expressions"
     name: "Parsing: Booleans & Nil"
     difficulty: hard
     description_md: |-
@@ -802,7 +802,7 @@ stages:
 
 
   - slug: "ra8"
-    primary_extension_slug: "parser"
+    primary_extension_slug: "parsing-expressions"
     name: "Parsing: Number literals"
     difficulty: medium
     description_md: |-
@@ -838,7 +838,7 @@ stages:
       In this stage, you'll implement support for parsing number literals.
 
   - slug: "th5"
-    primary_extension_slug: "parser"
+    primary_extension_slug: "parsing-expressions"
     name: "Parsing: String literals"
     difficulty: medium
     description_md: |-
@@ -874,7 +874,7 @@ stages:
       In this stage, you'll implement support for parsing string literals.
 
   - slug: "xe6"
-    primary_extension_slug: "parser"
+    primary_extension_slug: "parsing-expressions"
     name: "Parsing: Parentheses"
     difficulty: medium
     description_md: |-
@@ -913,7 +913,7 @@ stages:
       In this stage, you'll implement support for parsing parentheses.
 
   - slug: "mq1"
-    primary_extension_slug: "parser"
+    primary_extension_slug: "parsing-expressions"
     name: "Parsing: Unary Operators"
     difficulty: medium
     description_md: |-
@@ -949,7 +949,7 @@ stages:
       In this stage, you'll implement support for parsing unary operators `!` and `-`.
 
   - slug: "wa9"
-    primary_extension_slug: "parser"
+    primary_extension_slug: "parsing-expressions"
     name: "Parsing: Multiplicative algebraic operators"
     difficulty: medium
     description_md: |-
@@ -985,7 +985,7 @@ stages:
       In this stage, you'll implement support for parsing multiplicative algebraic operators `*` and `/`.
 
   - slug: "yf2"
-    primary_extension_slug: "parser"
+    primary_extension_slug: "parsing-expressions"
     name: "Parsing: Additive algebraic operators"
     difficulty: medium
     description_md: |-
@@ -1021,7 +1021,7 @@ stages:
       In this stage, you'll implement support for parsing additive algebraic operators `+` and `-`.
 
   - slug: "uh4"
-    primary_extension_slug: "parser"
+    primary_extension_slug: "parsing-expressions"
     name: "Parsing: Comparison operators"
     difficulty: medium
     description_md: |-
@@ -1057,7 +1057,7 @@ stages:
       In this stage, you'll implement support for parsing comparison operators `>`, `<`, `>=` & `<=`.
 
   - slug: "ht8"
-    primary_extension_slug: "parser"
+    primary_extension_slug: "parsing-expressions"
     name: "Parsing: Equality operators"
     difficulty: medium
     description_md: |-
@@ -1093,7 +1093,7 @@ stages:
       In this stage, you'll implement support for parsing equality operators `==` & `!=`.
 
   - slug: "wz8"
-    primary_extension_slug: "parser"
+    primary_extension_slug: "parsing-expressions"
     name: "Parsing: Syntactic errors"
     difficulty: medium
     description_md: |-

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -50,7 +50,7 @@ marketing:
 
 
 extensions:
-  - slug: "parser"
+  - slug: "parsing-expressions"
     name: "Parsing Expressions"
     description_markdown: |
       In this challenge extension you'll add the ability to parse expressions to your interpreter implementation.

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -687,7 +687,7 @@ stages:
       - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/tree/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/scanning)
       - When scanning for tokens, it's valid to have "unbalanced" parentheses or braces. When we get to parsing expressions in later stages, these cases will be highlighted as errors.
     marketing_md: |-
-      In this stage, you'll implement support for scanning identifers.
+      In this stage, you'll implement support for scanning identifiers.
 
   - slug: "pq5"
     name: "Scanning: Reserved words"
@@ -813,7 +813,7 @@ stages:
 
       ### Tests
 
-      The tester will run a series of tests with `test.lox` files that contain number literals, we include both ints and floats.
+      The tester will run a series of tests with `test.lox` files that contain number literals, we include both integers and floats.
 
       For example, if `test.lox` contains the following:
 

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -1070,7 +1070,7 @@ stages:
     name: "Parsing: Equality operators"
     difficulty: medium
     description_md: |-
-      In this stage, you'll add support for parsing equality operators. You need to support the two comparison operators `==` & `!=`.
+      In this stage, you'll add support for parsing equality operators: `==` & `!=`.
 
       ### Book reference
 
@@ -1106,7 +1106,7 @@ stages:
     name: "Parsing: Syntactic errors"
     difficulty: medium
     description_md: |-
-      In this stage, you'll add support for handling syntax errors in the expression passed to you. We won't check the exact error message on stderr just the proper exitCode will suffice.
+      In this stage, you'll add support for handling syntax errors in expressions.
 
       ### Book reference
 
@@ -1129,11 +1129,11 @@ stages:
       [line 1] Error at ')': Expect expression.
       ```
 
-      The tester will assert that the exitCode is 65, if there was a syntax error in the expression.
+      The tester will assert that the exit code is 65.
 
       ### Notes
 
       - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/parse.lox)
-      - We won't check the exact error message on stderr just the proper exitCode will suffice.
+      - The tester won't check the exact error message in this stage, it will only check that the program exits with code 65.
     marketing_md: |-
-      In this stage, you'll implement support for parsing syntax errors.
+      In this stage, you'll implement support for handling syntax errors in expressions.


### PR DESCRIPTION
This pull request adds stage descriptions for all stages in the project. The descriptions have been added in three separate commits: the first commit adds descriptions for the first 5 stages, the second commit adds descriptions for the next 3 stages, and the final commit adds descriptions for the remaining stages. This change improves the documentation of the project and provides more context for each stage.