### PR TITLE
Add a table of reference character names [#xc5 Scanning: Other single-character tokens]

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -310,6 +310,22 @@ stages:
 
       The tester will assert that the stdout of your program matches the format above.
 
+      Reference character names:
+
+      | Character | Name |
+      | :-------: | :---------: |
+      | , | COMMA |
+      | . | DOT |
+      | - | MINUS |
+      | + | PLUS |
+      | ; | SEMICOLON |
+      | / | SLASH |
+      | * | STAR |
+      | ( | LEFT_PAREN |
+      | ) | RIGHT_PAREN |
+      | { | LEFT_BRACE |
+      | } | RIGHT_BRACE |
+
       ### Notes
 
       - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/tree/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/scanning)

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -310,21 +310,21 @@ stages:
 
       The tester will assert that the stdout of your program matches the format above.
 
-      Reference character names:
+      Here's a list of all the single-character tokens along with their types:
 
-      | Character | Name |
-      | :-------: | :---------: |
-      | , | COMMA |
-      | . | DOT |
-      | - | MINUS |
-      | + | PLUS |
-      | ; | SEMICOLON |
-      | / | SLASH |
-      | * | STAR |
-      | ( | LEFT_PAREN |
-      | ) | RIGHT_PAREN |
-      | { | LEFT_BRACE |
-      | } | RIGHT_BRACE |
+      | Token | Token Type |
+      | :---: | :-----------: |
+      | `,` | `COMMA` |
+      | `.` | `DOT` |
+      | `-` | `MINUS` |
+      | `+` | `PLUS` |
+      | `;` | `SEMICOLON` |
+      | `/` | `SLASH` |
+      | `*` | `STAR` |
+      | `(` | `LEFT_PAREN` |
+      | `)` | `RIGHT_PAREN` |
+      | `{` | `LEFT_BRACE` |
+      | `}` | `RIGHT_BRACE` |
 
       ### Notes
 


### PR DESCRIPTION
<img width="676" alt="image" src="https://github.com/user-attachments/assets/c3b43b3d-2bba-445a-9166-be77c806b1e8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new reference table listing character symbols and their corresponding names to clarify token representations in the language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->