### PR TITLE
[Interpreter] CC-1646: Upgrade Python support to 3.13

### DIFF
--- a/compiled_starters/python/README.md
+++ b/compiled_starters/python/README.md
@@ -43,7 +43,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `python (3.12)` installed locally
+1. Ensure you have `python (3.13)` installed locally
 2. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.py`.
 3. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/python/codecrafters.yml
+++ b/compiled_starters/python/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Python version used to run your code
 # on Codecrafters.
 #
-# Available versions: python-3.12
-language_pack: python-3.12
+# Available versions: python-3.13
+language_pack: python-3.13

--- a/dockerfiles/python-3.13.Dockerfile
+++ b/dockerfiles/python-3.13.Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM python:3.13-alpine
+
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Pipfile,Pipfile.lock"
+
+# pipenv uses this to store virtualenvs
+ENV WORKON_HOME=/venvs
+
+RUN pip install --no-cache-dir "pipenv>=2024.4.0"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+RUN pipenv install
+
+# Force environment creation
+RUN pipenv run python3 -c "1+1"

--- a/solutions/python/01-ry8/code/README.md
+++ b/solutions/python/01-ry8/code/README.md
@@ -43,7 +43,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `python (3.12)` installed locally
+1. Ensure you have `python (3.13)` installed locally
 2. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.py`.
 3. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/python/01-ry8/code/codecrafters.yml
+++ b/solutions/python/01-ry8/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Python version used to run your code
 # on Codecrafters.
 #
-# Available versions: python-3.12
-language_pack: python-3.12
+# Available versions: python-3.13
+language_pack: python-3.13

--- a/starter_templates/python/config.yml
+++ b/starter_templates/python/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: python (3.12)
+  required_executable: python (3.13)
   user_editable_file: app/main.py


### PR DESCRIPTION
Upgrade the Python version in configuration and documentation files to 3.13. Introduce a Dockerfile for setting up a Python 3.13 environment with Pipenv.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new Docker environment optimized for Python 3.13, enhancing dependency management.
  
- **Chores**
  - Upgraded documentation and configuration files to require Python 3.13, ensuring compatibility with the updated environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->