### PR TITLE
[Interpreter] CC-1745: Upgrade Run to v1.2, Rust to v1.86, and Elixir to v1.18

### DIFF
--- a/compiled_starters/elixir/codecrafters.yml
+++ b/compiled_starters/elixir/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Elixir version used to run your code
 # on Codecrafters.
 #
-# Available versions: elixir-1.17
-language_pack: elixir-1.17
+# Available versions: elixir-1.18
+language_pack: elixir-1.18

--- a/compiled_starters/elixir/mix.exs
+++ b/compiled_starters/elixir/mix.exs
@@ -6,7 +6,7 @@ defmodule App.MixProject do
     [
       app: :codecrafters_interpreter,
       version: "1.0.0",
-      elixir: "~> 1.17",
+      elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       escript: [main_module: CLI]

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -43,7 +43,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.85)` installed locally
+1. Ensure you have `cargo (1.86)` installed locally
 2. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/compiled_starters/rust/codecrafters.yml
+++ b/compiled_starters/rust/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.85
-language_pack: rust-1.85
+# Available versions: rust-1.86
+language_pack: rust-1.86

--- a/compiled_starters/typescript/README.md
+++ b/compiled_starters/typescript/README.md
@@ -43,7 +43,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `bun (1.1)` installed locally
+1. Ensure you have `bun (1.2)` installed locally
 2. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.ts`.
 3. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/typescript/codecrafters.yml
+++ b/compiled_starters/typescript/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the TypeScript version used to run your code
 # on Codecrafters.
 #
-# Available versions: bun-1.1
-language_pack: bun-1.1
+# Available versions: bun-1.2
+language_pack: bun-1.2

--- a/dockerfiles/bun-1.2.Dockerfile
+++ b/dockerfiles/bun-1.2.Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM oven/bun:1.2-alpine
+
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="package.json,bun.lockb"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# For reproducible builds.
+# This will install the exact versions of each package specified in the lockfile.
+# If package.json disagrees with bun.lockb, Bun will exit with an error. The lockfile will not be updated.
+RUN bun install --frozen-lockfile
+
+# If the node_modules directory exists, move it to /app-cached
+RUN mkdir -p /app-cached
+RUN if [ -d "/app/node_modules" ]; then mv /app/node_modules /app-cached; fi

--- a/dockerfiles/elixir-1.18.Dockerfile
+++ b/dockerfiles/elixir-1.18.Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM elixir:1.18.3-alpine
+
+# Ensures the container is re-built if dependency files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="mix.exs"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# install hex + rebar
+RUN mix local.hex --force && \
+  mix local.rebar --force
+
+# install and compile mix dependencies
+RUN mix deps.get && \
+  mix deps.compile
+
+# Install & cache deps
+RUN .codecrafters/compile.sh
+
+RUN mkdir -p /app-cached
+RUN if [ -d "/app/_build" ]; then mv /app/_build /app-cached; fi
+RUN if [ -d "/app/deps" ]; then mv /app/deps /app-cached; fi

--- a/dockerfiles/rust-1.86.Dockerfile
+++ b/dockerfiles/rust-1.86.Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM rust:1.86-bookworm
+
+# Rebuild the container if these files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Cargo.toml,Cargo.lock"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs cargo build
+RUN .codecrafters/compile.sh

--- a/solutions/elixir/01-ry8/code/codecrafters.yml
+++ b/solutions/elixir/01-ry8/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Elixir version used to run your code
 # on Codecrafters.
 #
-# Available versions: elixir-1.17
-language_pack: elixir-1.17
+# Available versions: elixir-1.18
+language_pack: elixir-1.18

--- a/solutions/elixir/01-ry8/code/mix.exs
+++ b/solutions/elixir/01-ry8/code/mix.exs
@@ -6,7 +6,7 @@ defmodule App.MixProject do
     [
       app: :codecrafters_interpreter,
       version: "1.0.0",
-      elixir: "~> 1.17",
+      elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       escript: [main_module: CLI]

--- a/solutions/rust/01-ry8/code/README.md
+++ b/solutions/rust/01-ry8/code/README.md
@@ -43,7 +43,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.85)` installed locally
+1. Ensure you have `cargo (1.86)` installed locally
 2. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/01-ry8/code/codecrafters.yml
+++ b/solutions/rust/01-ry8/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.85
-language_pack: rust-1.85
+# Available versions: rust-1.86
+language_pack: rust-1.86

--- a/solutions/typescript/01-ry8/code/README.md
+++ b/solutions/typescript/01-ry8/code/README.md
@@ -43,7 +43,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `bun (1.1)` installed locally
+1. Ensure you have `bun (1.2)` installed locally
 2. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.ts`.
 3. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/typescript/01-ry8/code/codecrafters.yml
+++ b/solutions/typescript/01-ry8/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the TypeScript version used to run your code
 # on Codecrafters.
 #
-# Available versions: bun-1.1
-language_pack: bun-1.1
+# Available versions: bun-1.2
+language_pack: bun-1.2

--- a/starter_templates/elixir/code/mix.exs
+++ b/starter_templates/elixir/code/mix.exs
@@ -6,7 +6,7 @@ defmodule App.MixProject do
     [
       app: :codecrafters_interpreter,
       version: "1.0.0",
-      elixir: "~> 1.17",
+      elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       escript: [main_module: CLI]

--- a/starter_templates/rust/config.yml
+++ b/starter_templates/rust/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: cargo (1.85)
+  required_executable: cargo (1.86)
   user_editable_file: src/main.rs

--- a/starter_templates/typescript/config.yml
+++ b/starter_templates/typescript/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: bun (1.1)
+  required_executable: bun (1.2)
   user_editable_file: app/main.ts


### PR DESCRIPTION
…files for Elixir 1.18, Rust 1.86, and Bun 1.2. Modify README and config files to reflect new version requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new build environments for Elixir 1.18, Rust 1.86, and Bun 1.2 to support the latest language versions.

- **Documentation**
  - Updated instructions and configuration files to require Elixir 1.18, Rust 1.86, and Bun 1.2 across relevant starter templates and solutions.

- **Chores**
  - Updated configuration files to reflect new default language versions for Elixir, Rust, and TypeScript environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->