### PR TITLE
Tweak placeholder comments in starter code

### DIFF
--- a/compiled_starters/c/src/main.c
+++ b/compiled_starters/c/src/main.c
@@ -27,7 +27,7 @@ int main(int argc, char *argv[]) {
         //     fprintf(stderr, "Scanner not implemented\n");
         //     exit(1);
         // } 
-        // printf("EOF  null\n"); // Placeholder, remove this line when implementing the scanner
+        // printf("EOF  null\n"); // Placeholder, replace this line when implementing the scanner
         
         free(file_contents);
     } else {

--- a/compiled_starters/cpp/src/main.cpp
+++ b/compiled_starters/cpp/src/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char *argv[]) {
         //     std::cerr << "Scanner not implemented" << std::endl;
         //     return 1;
         // }
-        // std::cout << "EOF  null" << std::endl; // Placeholder, remove this line when implementing the scanner
+        // std::cout << "EOF  null" << std::endl; // Placeholder, replace this line when implementing the scanner
         
     } else {
         std::cerr << "Unknown command: " << command << std::endl;

--- a/compiled_starters/csharp/src/main.cs
+++ b/compiled_starters/csharp/src/main.cs
@@ -28,5 +28,5 @@ Console.Error.WriteLine("Logs from your program will appear here!");
 // }
 // else
 // {
-//     Console.WriteLine("EOF  null"); // Placeholder, remove this line when implementing the scanner
+//     Console.WriteLine("EOF  null"); // Placeholder, replace this line when implementing the scanner
 // }

--- a/compiled_starters/elixir/lib/main.ex
+++ b/compiled_starters/elixir/lib/main.ex
@@ -12,7 +12,7 @@ defmodule CLI do
             # if file_contents != "" do
             #   raise "Scanner not implemented"
             # else
-            #   IO.puts("EOF  null") # Placeholder, remove this line when implementing the scanner
+            #   IO.puts("EOF  null") # Placeholder, replace this line when implementing the scanner
             # end
             :ok # Remove this when you uncomment the code above, it's just a placeholder for the compiler
 

--- a/compiled_starters/go/app/main.go
+++ b/compiled_starters/go/app/main.go
@@ -33,6 +33,6 @@ func main() {
 	// if len(fileContents) > 0 {
 	// 	panic("Scanner not implemented")
 	// } else {
-	// 	fmt.Println("EOF  null") // Placeholder, remove this line when implementing the scanner
+	// 	fmt.Println("EOF  null") // Placeholder, replace this line when implementing the scanner
 	// }
 }

--- a/compiled_starters/java/src/main/java/Main.java
+++ b/compiled_starters/java/src/main/java/Main.java
@@ -33,7 +33,7 @@ public class Main {
     // if (fileContents.length() > 0) {
     //   throw new RuntimeException("Scanner not implemented");
     // } else {
-    //   System.out.println("EOF  null"); // Placeholder, remove this line when implementing the scanner
+    //   System.out.println("EOF  null"); // Placeholder, replace this line when implementing the scanner
     // }
   }
 }

--- a/compiled_starters/kotlin/src/main/kotlin/Main.kt
+++ b/compiled_starters/kotlin/src/main/kotlin/Main.kt
@@ -24,6 +24,6 @@ fun main(args: Array<String>) {
     // if (fileContents.isNotEmpty()) {
     //     throw NotImplementedError("Scanner not implemented")
     // } else {
-    //     println("EOF  null") // Placeholder, remove this line when implementing the scanner
+    //     println("EOF  null") // Placeholder, replace this line when implementing the scanner
     // }
 }

--- a/compiled_starters/ocaml/src/main.ml
+++ b/compiled_starters/ocaml/src/main.ml
@@ -20,5 +20,5 @@ let () =
     failwith "Scanner not implemented"
   else
     (* Uncomment this block to pass the first stage *)
-    (* print_endline "EOF  null"; (* Placeholder, remove this line when implementing the scanner *) *)
+    (* print_endline "EOF  null"; (* Placeholder, replace this line when implementing the scanner *) *)
     ()

--- a/compiled_starters/php/app/main.php
+++ b/compiled_starters/php/app/main.php
@@ -23,5 +23,5 @@ fwrite(STDERR, "Logs from your program will appear here!\n");
 // if ($file_contents) {
 //     throw new Exception("Scanner not implemented");
 // } else {
-//     echo "EOF  null\n"; // Placeholder, remove this line when implementing the scanner
+//     echo "EOF  null\n"; // Placeholder, replace this line when implementing the scanner
 // }

--- a/compiled_starters/python/app/main.py
+++ b/compiled_starters/python/app/main.py
@@ -23,7 +23,7 @@ def main():
     # if file_contents:
     #     raise NotImplementedError("Scanner not implemented")
     # else:
-    #     print("EOF  null") # Placeholder, remove this line when implementing the scanner
+    #     print("EOF  null") # Placeholder, replace this line when implementing the scanner
 
 
 if __name__ == "__main__":

--- a/compiled_starters/rust/src/main.rs
+++ b/compiled_starters/rust/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
             // if !file_contents.is_empty() {
             //     panic!("Scanner not implemented");
             // } else {
-            //     println!("EOF  null"); // Placeholder, remove this line when implementing the scanner
+            //     println!("EOF  null"); // Placeholder, replace this line when implementing the scanner
             // }
         }
         _ => {

--- a/compiled_starters/zig/src/main.zig
+++ b/compiled_starters/zig/src/main.zig
@@ -27,6 +27,6 @@ pub fn main() !void {
     // if (file_contents.len > 0) {
     //     @panic("Scanner not implemented");
     // } else {
-    //     try std.io.getStdOut().writer().print("EOF  null\n", .{}); // Placeholder, remove this line when implementing the scanner
+    //     try std.io.getStdOut().writer().print("EOF  null\n", .{}); // Placeholder, replace this line when implementing the scanner
     // }
 }

--- a/solutions/c/01-ry8/code/src/main.c
+++ b/solutions/c/01-ry8/code/src/main.c
@@ -23,7 +23,7 @@ int main(int argc, char *argv[]) {
             fprintf(stderr, "Scanner not implemented\n");
             exit(1);
         }
-        printf("EOF  null\n"); // Placeholder, remove this line when implementing the scanner
+        printf("EOF  null\n"); // Placeholder, replace this line when implementing the scanner
         
         free(file_contents);
     } else {

--- a/solutions/c/01-ry8/diff/src/main.c.diff
+++ b/solutions/c/01-ry8/diff/src/main.c.diff
@@ -28,12 +28,12 @@
 -        //     fprintf(stderr, "Scanner not implemented\n");
 -        //     exit(1);
 -        // } 
--        // printf("EOF  null\n"); // Placeholder, remove this line when implementing the scanner
+-        // printf("EOF  null\n"); // Placeholder, replace this line when implementing the scanner
 +        if (strlen(file_contents) > 0) {
 +            fprintf(stderr, "Scanner not implemented\n");
 +            exit(1);
 +        }
-+        printf("EOF  null\n"); // Placeholder, remove this line when implementing the scanner
++        printf("EOF  null\n"); // Placeholder, replace this line when implementing the scanner
          
          free(file_contents);
      } else {

--- a/solutions/c/01-ry8/explanation.md
+++ b/solutions/c/01-ry8/explanation.md
@@ -1,6 +1,6 @@
 The entry point for your Interpreter implementation is in `src/main.c`.
 
-Study and uncomment the relevant code:
+Study and uncomment the relevant code: 
 
 ```c
 // Uncomment this block to pass the first stage

--- a/solutions/c/01-ry8/explanation.md
+++ b/solutions/c/01-ry8/explanation.md
@@ -1,6 +1,6 @@
 The entry point for your Interpreter implementation is in `src/main.c`.
 
-Study and uncomment the relevant code: 
+Study and uncomment the relevant code:
 
 ```c
 // Uncomment this block to pass the first stage
@@ -8,7 +8,7 @@ if (strlen(file_contents) > 0) {
     fprintf(stderr, "Scanner not implemented\n");
     exit(1);
 }
-printf("EOF  null\n"); // Placeholder, remove this line when implementing the scanner
+printf("EOF  null\n"); // Placeholder, replace this line when implementing the scanner
 ```
 
 Push your changes to pass the first stage:

--- a/solutions/cpp/01-ry8/code/src/main.cpp
+++ b/solutions/cpp/01-ry8/code/src/main.cpp
@@ -25,7 +25,7 @@ int main(int argc, char *argv[]) {
             std::cerr << "Scanner not implemented" << std::endl;
             return 1;
         }
-        std::cout << "EOF  null" << std::endl; // Placeholder, remove this line when implementing the scanner
+        std::cout << "EOF  null" << std::endl; // Placeholder, replace this line when implementing the scanner
         
     } else {
         std::cerr << "Unknown command: " << command << std::endl;

--- a/solutions/cpp/01-ry8/diff/src/main.cpp.diff
+++ b/solutions/cpp/01-ry8/diff/src/main.cpp.diff
@@ -31,12 +31,12 @@
 -        //     std::cerr << "Scanner not implemented" << std::endl;
 -        //     return 1;
 -        // }
--        // std::cout << "EOF  null" << std::endl; // Placeholder, remove this line when implementing the scanner
+-        // std::cout << "EOF  null" << std::endl; // Placeholder, replace this line when implementing the scanner
 +        if (!file_contents.empty()) {
 +            std::cerr << "Scanner not implemented" << std::endl;
 +            return 1;
 +        }
-+        std::cout << "EOF  null" << std::endl; // Placeholder, remove this line when implementing the scanner
++        std::cout << "EOF  null" << std::endl; // Placeholder, replace this line when implementing the scanner
          
      } else {
          std::cerr << "Unknown command: " << command << std::endl;

--- a/solutions/cpp/01-ry8/explanation.md
+++ b/solutions/cpp/01-ry8/explanation.md
@@ -1,6 +1,6 @@
 The entry point for your Interpreter implementation is in `src/main.cpp`.
 
-Study and uncomment the relevant code:
+Study and uncomment the relevant code: 
 
 ```cpp
 // Uncomment this block to pass the first stage

--- a/solutions/cpp/01-ry8/explanation.md
+++ b/solutions/cpp/01-ry8/explanation.md
@@ -1,6 +1,6 @@
 The entry point for your Interpreter implementation is in `src/main.cpp`.
 
-Study and uncomment the relevant code: 
+Study and uncomment the relevant code:
 
 ```cpp
 // Uncomment this block to pass the first stage
@@ -9,7 +9,7 @@ if (!file_contents.empty()) {
     std::cerr << "Scanner not implemented" << std::endl;
     return 1;
 }
-std::cout << "EOF  null" << std::endl; // Placeholder, remove this line when implementing the scanner
+std::cout << "EOF  null" << std::endl; // Placeholder, replace this line when implementing the scanner
 ```
 
 Push your changes to pass the first stage:

--- a/solutions/csharp/01-ry8/code/src/main.cs
+++ b/solutions/csharp/01-ry8/code/src/main.cs
@@ -24,5 +24,5 @@ if (!string.IsNullOrEmpty(fileContents))
 }
 else
 {
-    Console.WriteLine("EOF  null"); // Placeholder, remove this line when implementing the scanner
+    Console.WriteLine("EOF  null"); // Placeholder, replace this line when implementing the scanner
 }

--- a/solutions/csharp/01-ry8/diff/src/main.cs.diff
+++ b/solutions/csharp/01-ry8/diff/src/main.cs.diff
@@ -29,7 +29,7 @@
 -// }
 -// else
 -// {
--//     Console.WriteLine("EOF  null"); // Placeholder, remove this line when implementing the scanner
+-//     Console.WriteLine("EOF  null"); // Placeholder, replace this line when implementing the scanner
 -// }
 +if (!string.IsNullOrEmpty(fileContents))
 +{
@@ -37,5 +37,5 @@
 +}
 +else
 +{
-+    Console.WriteLine("EOF  null"); // Placeholder, remove this line when implementing the scanner
++    Console.WriteLine("EOF  null"); // Placeholder, replace this line when implementing the scanner
 +}

--- a/solutions/csharp/01-ry8/explanation.md
+++ b/solutions/csharp/01-ry8/explanation.md
@@ -1,6 +1,6 @@
 The entry point for your Interpreter implementation is in `src/main.cs`.
 
-Study and uncomment the relevant code: 
+Study and uncomment the relevant code:
 
 ```csharp
 // Uncomment this block to pass the first stage
@@ -10,7 +10,7 @@ if (!string.IsNullOrEmpty(fileContents))
 }
 else
 {
-    Console.WriteLine("EOF  null"); // Placeholder, remove this line when implementing the scanner
+    Console.WriteLine("EOF  null"); // Placeholder, replace this line when implementing the scanner
 }
 ```
 

--- a/solutions/csharp/01-ry8/explanation.md
+++ b/solutions/csharp/01-ry8/explanation.md
@@ -1,6 +1,6 @@
 The entry point for your Interpreter implementation is in `src/main.cs`.
 
-Study and uncomment the relevant code:
+Study and uncomment the relevant code: 
 
 ```csharp
 // Uncomment this block to pass the first stage

--- a/solutions/elixir/01-ry8/code/lib/main.ex
+++ b/solutions/elixir/01-ry8/code/lib/main.ex
@@ -8,7 +8,7 @@ defmodule CLI do
             if file_contents != "" do
               raise "Scanner not implemented"
             else
-              IO.puts("EOF  null") # Placeholder, remove this line when implementing the scanner
+              IO.puts("EOF  null") # Placeholder, replace this line when implementing the scanner
             end
             :ok # Remove this when you uncomment the code above, it's just a placeholder for the compiler
 

--- a/solutions/elixir/01-ry8/diff/lib/main.ex.diff
+++ b/solutions/elixir/01-ry8/diff/lib/main.ex.diff
@@ -13,12 +13,12 @@
 -            # if file_contents != "" do
 -            #   raise "Scanner not implemented"
 -            # else
--            #   IO.puts("EOF  null") # Placeholder, remove this line when implementing the scanner
+-            #   IO.puts("EOF  null") # Placeholder, replace this line when implementing the scanner
 -            # end
 +            if file_contents != "" do
 +              raise "Scanner not implemented"
 +            else
-+              IO.puts("EOF  null") # Placeholder, remove this line when implementing the scanner
++              IO.puts("EOF  null") # Placeholder, replace this line when implementing the scanner
 +            end
              :ok # Remove this when you uncomment the code above, it's just a placeholder for the compiler
 

--- a/solutions/elixir/01-ry8/explanation.md
+++ b/solutions/elixir/01-ry8/explanation.md
@@ -1,13 +1,13 @@
 The entry point for your Interpreter implementation is in `lib/main.ex`.
 
-Study and uncomment the relevant code: 
+Study and uncomment the relevant code:
 
 ```elixir
 # TODO: Uncomment this when implementing the scanner
 if file_contents != "" do
   raise "Scanner not implemented"
 else
-  IO.puts("EOF  null") # Placeholder, remove this line when implementing the scanner
+  IO.puts("EOF  null") # Placeholder, replace this line when implementing the scanner
 end
 ```
 

--- a/solutions/elixir/01-ry8/explanation.md
+++ b/solutions/elixir/01-ry8/explanation.md
@@ -1,6 +1,6 @@
 The entry point for your Interpreter implementation is in `lib/main.ex`.
 
-Study and uncomment the relevant code:
+Study and uncomment the relevant code: 
 
 ```elixir
 # TODO: Uncomment this when implementing the scanner

--- a/solutions/go/01-ry8/code/app/main.go
+++ b/solutions/go/01-ry8/code/app/main.go
@@ -28,6 +28,6 @@ func main() {
 	if len(fileContents) > 0 {
 		panic("Scanner not implemented")
 	} else {
-		fmt.Println("EOF  null") // Placeholder, remove this line when implementing the scanner
+		fmt.Println("EOF  null") // Placeholder, replace this line when implementing the scanner
 	}
 }

--- a/solutions/go/01-ry8/diff/app/main.go.diff
+++ b/solutions/go/01-ry8/diff/app/main.go.diff
@@ -34,7 +34,7 @@
 -	// if len(fileContents) > 0 {
 -	// 	panic("Scanner not implemented")
 -	// } else {
--	// 	fmt.Println("EOF  null") // Placeholder, remove this line when implementing the scanner
+-	// 	fmt.Println("EOF  null") // Placeholder, replace this line when implementing the scanner
 -	// }
 +	filename := os.Args[2]
 +	fileContents, err := os.ReadFile(filename)
@@ -46,6 +46,6 @@
 +	if len(fileContents) > 0 {
 +		panic("Scanner not implemented")
 +	} else {
-+		fmt.Println("EOF  null") // Placeholder, remove this line when implementing the scanner
++		fmt.Println("EOF  null") // Placeholder, replace this line when implementing the scanner
 +	}
  }

--- a/solutions/go/01-ry8/explanation.md
+++ b/solutions/go/01-ry8/explanation.md
@@ -1,6 +1,6 @@
 The entry point for your Interpreter implementation is in `app/main.go`.
 
-Study and uncomment the relevant code: 
+Study and uncomment the relevant code:
 
 ```go
 // Uncomment this block to pass the first stage
@@ -15,7 +15,7 @@ if err != nil {
 if len(fileContents) > 0 {
 	panic("Scanner not implemented")
 } else {
-	fmt.Println("EOF  null") // Placeholder, remove this line when implementing the scanner
+	fmt.Println("EOF  null") // Placeholder, replace this line when implementing the scanner
 }
 ```
 

--- a/solutions/go/01-ry8/explanation.md
+++ b/solutions/go/01-ry8/explanation.md
@@ -1,6 +1,6 @@
 The entry point for your Interpreter implementation is in `app/main.go`.
 
-Study and uncomment the relevant code:
+Study and uncomment the relevant code: 
 
 ```go
 // Uncomment this block to pass the first stage

--- a/solutions/java/01-ry8/code/src/main/java/Main.java
+++ b/solutions/java/01-ry8/code/src/main/java/Main.java
@@ -28,7 +28,7 @@ public class Main {
     if (fileContents.length() > 0) {
       throw new RuntimeException("Scanner not implemented");
     } else {
-      System.out.println("EOF  null"); // Placeholder, remove this line when implementing the scanner
+      System.out.println("EOF  null"); // Placeholder, replace this line when implementing the scanner
     }
   }
 }

--- a/solutions/java/01-ry8/diff/src/main/java/Main.java.diff
+++ b/solutions/java/01-ry8/diff/src/main/java/Main.java.diff
@@ -34,12 +34,12 @@
 -    // if (fileContents.length() > 0) {
 -    //   throw new RuntimeException("Scanner not implemented");
 -    // } else {
--    //   System.out.println("EOF  null"); // Placeholder, remove this line when implementing the scanner
+-    //   System.out.println("EOF  null"); // Placeholder, replace this line when implementing the scanner
 -    // }
 +    if (fileContents.length() > 0) {
 +      throw new RuntimeException("Scanner not implemented");
 +    } else {
-+      System.out.println("EOF  null"); // Placeholder, remove this line when implementing the scanner
++      System.out.println("EOF  null"); // Placeholder, replace this line when implementing the scanner
 +    }
    }
  }

--- a/solutions/java/01-ry8/explanation.md
+++ b/solutions/java/01-ry8/explanation.md
@@ -1,6 +1,6 @@
 The entry point for your Interpreter implementation is in `src/main/java/Main.java`.
 
-Study and uncomment the relevant code: 
+Study and uncomment the relevant code:
 
 ```java
 // Uncomment this block to pass the first stage
@@ -8,7 +8,7 @@ Study and uncomment the relevant code:
 if (fileContents.length() > 0) {
   throw new RuntimeException("Scanner not implemented");
 } else {
-  System.out.println("EOF  null"); // Placeholder, remove this line when implementing the scanner
+  System.out.println("EOF  null"); // Placeholder, replace this line when implementing the scanner
 }
 ```
 

--- a/solutions/java/01-ry8/explanation.md
+++ b/solutions/java/01-ry8/explanation.md
@@ -1,6 +1,6 @@
 The entry point for your Interpreter implementation is in `src/main/java/Main.java`.
 
-Study and uncomment the relevant code:
+Study and uncomment the relevant code: 
 
 ```java
 // Uncomment this block to pass the first stage

--- a/solutions/kotlin/01-ry8/code/src/main/kotlin/Main.kt
+++ b/solutions/kotlin/01-ry8/code/src/main/kotlin/Main.kt
@@ -20,6 +20,6 @@ fun main(args: Array<String>) {
     if (fileContents.isNotEmpty()) {
         throw NotImplementedError("Scanner not implemented")
     } else {
-        println("EOF  null") // Placeholder, remove this line when implementing the scanner
+        println("EOF  null") // Placeholder, replace this line when implementing the scanner
     }
 }

--- a/solutions/kotlin/01-ry8/diff/src/main/kotlin/Main.kt.diff
+++ b/solutions/kotlin/01-ry8/diff/src/main/kotlin/Main.kt.diff
@@ -25,11 +25,11 @@
 -    // if (fileContents.isNotEmpty()) {
 -    //     throw NotImplementedError("Scanner not implemented")
 -    // } else {
--    //     println("EOF  null") // Placeholder, remove this line when implementing the scanner
+-    //     println("EOF  null") // Placeholder, replace this line when implementing the scanner
 -    // }
 +    if (fileContents.isNotEmpty()) {
 +        throw NotImplementedError("Scanner not implemented")
 +    } else {
-+        println("EOF  null") // Placeholder, remove this line when implementing the scanner
++        println("EOF  null") // Placeholder, replace this line when implementing the scanner
 +    }
  }

--- a/solutions/kotlin/01-ry8/explanation.md
+++ b/solutions/kotlin/01-ry8/explanation.md
@@ -1,6 +1,6 @@
 The entry point for your Interpreter implementation is in `src/main/kotlin/Main.kt`.
 
-Study and uncomment the relevant code:
+Study and uncomment the relevant code: 
 
 ```kotlin
 // Uncomment this block to pass the first stage

--- a/solutions/kotlin/01-ry8/explanation.md
+++ b/solutions/kotlin/01-ry8/explanation.md
@@ -1,13 +1,13 @@
 The entry point for your Interpreter implementation is in `src/main/kotlin/Main.kt`.
 
-Study and uncomment the relevant code: 
+Study and uncomment the relevant code:
 
 ```kotlin
 // Uncomment this block to pass the first stage
 if (fileContents.isNotEmpty()) {
     throw NotImplementedError("Scanner not implemented")
 } else {
-    println("EOF  null") // Placeholder, remove this line when implementing the scanner
+    println("EOF  null") // Placeholder, replace this line when implementing the scanner
 }
 ```
 

--- a/solutions/ocaml/01-ry8/code/src/main.ml
+++ b/solutions/ocaml/01-ry8/code/src/main.ml
@@ -16,5 +16,5 @@ let () =
     (* Implement & use your scanner here *)
     failwith "Scanner not implemented"
   else
-    print_endline "EOF  null"; (* Placeholder, remove this line when implementing the scanner *)
+    print_endline "EOF  null"; (* Placeholder, replace this line when implementing the scanner *)
     ()

--- a/solutions/ocaml/01-ry8/diff/src/main.ml.diff
+++ b/solutions/ocaml/01-ry8/diff/src/main.ml.diff
@@ -21,6 +21,6 @@
      failwith "Scanner not implemented"
    else
 -    (* Uncomment this block to pass the first stage *)
--    (* print_endline "EOF  null"; (* Placeholder, remove this line when implementing the scanner *) *)
-+    print_endline "EOF  null"; (* Placeholder, remove this line when implementing the scanner *)
+-    (* print_endline "EOF  null"; (* Placeholder, replace this line when implementing the scanner *) *)
++    print_endline "EOF  null"; (* Placeholder, replace this line when implementing the scanner *)
      ()

--- a/solutions/ocaml/01-ry8/explanation.md
+++ b/solutions/ocaml/01-ry8/explanation.md
@@ -1,6 +1,6 @@
 The entry point for your Interpreter implementation is in `src/main.ml`.
 
-Study and uncomment the relevant code:
+Study and uncomment the relevant code: 
 
 ```ocaml
 (* Uncomment this block to pass the first stage *)

--- a/solutions/ocaml/01-ry8/explanation.md
+++ b/solutions/ocaml/01-ry8/explanation.md
@@ -1,10 +1,10 @@
 The entry point for your Interpreter implementation is in `src/main.ml`.
 
-Study and uncomment the relevant code: 
+Study and uncomment the relevant code:
 
 ```ocaml
 (* Uncomment this block to pass the first stage *)
-print_endline "EOF  null"; (* Placeholder, remove this line when implementing the scanner *)
+print_endline "EOF  null"; (* Placeholder, replace this line when implementing the scanner *)
 ```
 
 Push your changes to pass the first stage:

--- a/solutions/php/01-ry8/code/app/main.php
+++ b/solutions/php/01-ry8/code/app/main.php
@@ -19,5 +19,5 @@ $file_contents = file_get_contents($filename);
 if ($file_contents) {
     throw new Exception("Scanner not implemented");
 } else {
-    echo "EOF  null\n"; // Placeholder, remove this line when implementing the scanner
+    echo "EOF  null\n"; // Placeholder, replace this line when implementing the scanner
 }

--- a/solutions/php/01-ry8/diff/app/main.php.diff
+++ b/solutions/php/01-ry8/diff/app/main.php.diff
@@ -24,10 +24,10 @@
 -// if ($file_contents) {
 -//     throw new Exception("Scanner not implemented");
 -// } else {
--//     echo "EOF  null\n"; // Placeholder, remove this line when implementing the scanner
+-//     echo "EOF  null\n"; // Placeholder, replace this line when implementing the scanner
 -// }
 +if ($file_contents) {
 +    throw new Exception("Scanner not implemented");
 +} else {
-+    echo "EOF  null\n"; // Placeholder, remove this line when implementing the scanner
++    echo "EOF  null\n"; // Placeholder, replace this line when implementing the scanner
 +}

--- a/solutions/php/01-ry8/explanation.md
+++ b/solutions/php/01-ry8/explanation.md
@@ -1,6 +1,6 @@
 The entry point for your Interpreter implementation is in `app/main.php`.
 
-Study and uncomment the relevant code:
+Study and uncomment the relevant code: 
 
 ```php
 // Uncomment this block to pass the first stage

--- a/solutions/php/01-ry8/explanation.md
+++ b/solutions/php/01-ry8/explanation.md
@@ -1,13 +1,13 @@
 The entry point for your Interpreter implementation is in `app/main.php`.
 
-Study and uncomment the relevant code: 
+Study and uncomment the relevant code:
 
 ```php
 // Uncomment this block to pass the first stage
 if ($file_contents) {
     throw new Exception("Scanner not implemented");
 } else {
-    echo "EOF  null\n"; // Placeholder, remove this line when implementing the scanner
+    echo "EOF  null\n"; // Placeholder, replace this line when implementing the scanner
 }
 ```
 

--- a/solutions/python/01-ry8/code/app/main.py
+++ b/solutions/python/01-ry8/code/app/main.py
@@ -19,7 +19,7 @@ def main():
     if file_contents:
         raise NotImplementedError("Scanner not implemented")
     else:
-        print("EOF  null") # Placeholder, remove this line when implementing the scanner
+        print("EOF  null") # Placeholder, replace this line when implementing the scanner
 
 
 if __name__ == "__main__":

--- a/solutions/python/01-ry8/diff/app/main.py.diff
+++ b/solutions/python/01-ry8/diff/app/main.py.diff
@@ -24,11 +24,11 @@
 -    # if file_contents:
 -    #     raise NotImplementedError("Scanner not implemented")
 -    # else:
--    #     print("EOF  null") # Placeholder, remove this line when implementing the scanner
+-    #     print("EOF  null") # Placeholder, replace this line when implementing the scanner
 +    if file_contents:
 +        raise NotImplementedError("Scanner not implemented")
 +    else:
-+        print("EOF  null") # Placeholder, remove this line when implementing the scanner
++        print("EOF  null") # Placeholder, replace this line when implementing the scanner
 
 
  if __name__ == "__main__":

--- a/solutions/python/01-ry8/explanation.md
+++ b/solutions/python/01-ry8/explanation.md
@@ -1,6 +1,6 @@
 The entry point for your Interpreter implementation is in `app/main.py`.
 
-Study and uncomment the relevant code:
+Study and uncomment the relevant code: 
 
 ```python
 # Uncomment this block to pass the first stage

--- a/solutions/python/01-ry8/explanation.md
+++ b/solutions/python/01-ry8/explanation.md
@@ -1,13 +1,13 @@
 The entry point for your Interpreter implementation is in `app/main.py`.
 
-Study and uncomment the relevant code: 
+Study and uncomment the relevant code:
 
 ```python
 # Uncomment this block to pass the first stage
 if file_contents:
     raise NotImplementedError("Scanner not implemented")
 else:
-    print("EOF  null") # Placeholder, remove this line when implementing the scanner
+    print("EOF  null") # Placeholder, replace this line when implementing the scanner
 ```
 
 Push your changes to pass the first stage:

--- a/solutions/rust/01-ry8/code/src/main.rs
+++ b/solutions/rust/01-ry8/code/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
             if !file_contents.is_empty() {
                 panic!("Scanner not implemented");
             } else {
-                println!("EOF  null"); // Placeholder, remove this line when implementing the scanner
+                println!("EOF  null"); // Placeholder, replace this line when implementing the scanner
             }
         }
         _ => {

--- a/solutions/rust/01-ry8/diff/src/main.rs.diff
+++ b/solutions/rust/01-ry8/diff/src/main.rs.diff
@@ -27,12 +27,12 @@
 -            // if !file_contents.is_empty() {
 -            //     panic!("Scanner not implemented");
 -            // } else {
--            //     println!("EOF  null"); // Placeholder, remove this line when implementing the scanner
+-            //     println!("EOF  null"); // Placeholder, replace this line when implementing the scanner
 -            // }
 +            if !file_contents.is_empty() {
 +                panic!("Scanner not implemented");
 +            } else {
-+                println!("EOF  null"); // Placeholder, remove this line when implementing the scanner
++                println!("EOF  null"); // Placeholder, replace this line when implementing the scanner
 +            }
          }
          _ => {

--- a/solutions/rust/01-ry8/explanation.md
+++ b/solutions/rust/01-ry8/explanation.md
@@ -1,6 +1,6 @@
 The entry point for your Interpreter implementation is in `src/main.rs`.
 
-Study and uncomment the relevant code:
+Study and uncomment the relevant code: 
 
 ```rust
 // Uncomment this block to pass the first stage

--- a/solutions/rust/01-ry8/explanation.md
+++ b/solutions/rust/01-ry8/explanation.md
@@ -1,13 +1,13 @@
 The entry point for your Interpreter implementation is in `src/main.rs`.
 
-Study and uncomment the relevant code: 
+Study and uncomment the relevant code:
 
 ```rust
 // Uncomment this block to pass the first stage
 if !file_contents.is_empty() {
     panic!("Scanner not implemented");
 } else {
-    println!("EOF  null"); // Placeholder, remove this line when implementing the scanner
+    println!("EOF  null"); // Placeholder, replace this line when implementing the scanner
 }
 ```
 

--- a/solutions/zig/01-ry8/code/src/main.zig
+++ b/solutions/zig/01-ry8/code/src/main.zig
@@ -23,6 +23,6 @@ pub fn main() !void {
     if (file_contents.len > 0) {
         @panic("Scanner not implemented");
     } else {
-        try std.io.getStdOut().writer().print("EOF  null\n", .{}); // Placeholder, remove this line when implementing the scanner
+        try std.io.getStdOut().writer().print("EOF  null\n", .{}); // Placeholder, replace this line when implementing the scanner
     }
 }

--- a/solutions/zig/01-ry8/diff/src/main.zig.diff
+++ b/solutions/zig/01-ry8/diff/src/main.zig.diff
@@ -28,11 +28,11 @@
 -    // if (file_contents.len > 0) {
 -    //     @panic("Scanner not implemented");
 -    // } else {
--    //     try std.io.getStdOut().writer().print("EOF  null\n", .{}); // Placeholder, remove this line when implementing the scanner
+-    //     try std.io.getStdOut().writer().print("EOF  null\n", .{}); // Placeholder, replace this line when implementing the scanner
 -    // }
 +    if (file_contents.len > 0) {
 +        @panic("Scanner not implemented");
 +    } else {
-+        try std.io.getStdOut().writer().print("EOF  null\n", .{}); // Placeholder, remove this line when implementing the scanner
++        try std.io.getStdOut().writer().print("EOF  null\n", .{}); // Placeholder, replace this line when implementing the scanner
 +    }
  }

--- a/solutions/zig/01-ry8/explanation.md
+++ b/solutions/zig/01-ry8/explanation.md
@@ -1,13 +1,13 @@
 The entry point for your Interpreter implementation is in `src/main.zig`.
 
-Study and uncomment the relevant code: 
+Study and uncomment the relevant code:
 
 ```zig
 // Uncomment this block to pass the first stage
 if (file_contents.len > 0) {
     @panic("Scanner not implemented");
 } else {
-    try std.io.getStdOut().writer().print("EOF  null\n", .{}); // Placeholder, remove this line when implementing the scanner
+    try std.io.getStdOut().writer().print("EOF  null\n", .{}); // Placeholder, replace this line when implementing the scanner
 }
 ```
 

--- a/solutions/zig/01-ry8/explanation.md
+++ b/solutions/zig/01-ry8/explanation.md
@@ -1,6 +1,6 @@
 The entry point for your Interpreter implementation is in `src/main.zig`.
 
-Study and uncomment the relevant code:
+Study and uncomment the relevant code: 
 
 ```zig
 // Uncomment this block to pass the first stage

--- a/starter_templates/c/code/src/main.c
+++ b/starter_templates/c/code/src/main.c
@@ -27,7 +27,7 @@ int main(int argc, char *argv[]) {
         //     fprintf(stderr, "Scanner not implemented\n");
         //     exit(1);
         // } 
-        // printf("EOF  null\n"); // Placeholder, remove this line when implementing the scanner
+        // printf("EOF  null\n"); // Placeholder, replace this line when implementing the scanner
         
         free(file_contents);
     } else {

--- a/starter_templates/cpp/code/src/main.cpp
+++ b/starter_templates/cpp/code/src/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char *argv[]) {
         //     std::cerr << "Scanner not implemented" << std::endl;
         //     return 1;
         // }
-        // std::cout << "EOF  null" << std::endl; // Placeholder, remove this line when implementing the scanner
+        // std::cout << "EOF  null" << std::endl; // Placeholder, replace this line when implementing the scanner
         
     } else {
         std::cerr << "Unknown command: " << command << std::endl;

--- a/starter_templates/csharp/code/src/main.cs
+++ b/starter_templates/csharp/code/src/main.cs
@@ -28,5 +28,5 @@ Console.Error.WriteLine("Logs from your program will appear here!");
 // }
 // else
 // {
-//     Console.WriteLine("EOF  null"); // Placeholder, remove this line when implementing the scanner
+//     Console.WriteLine("EOF  null"); // Placeholder, replace this line when implementing the scanner
 // }

--- a/starter_templates/elixir/code/lib/main.ex
+++ b/starter_templates/elixir/code/lib/main.ex
@@ -12,7 +12,7 @@ defmodule CLI do
             # if file_contents != "" do
             #   raise "Scanner not implemented"
             # else
-            #   IO.puts("EOF  null") # Placeholder, remove this line when implementing the scanner
+            #   IO.puts("EOF  null") # Placeholder, replace this line when implementing the scanner
             # end
             :ok # Remove this when you uncomment the code above, it's just a placeholder for the compiler
 

--- a/starter_templates/go/code/app/main.go
+++ b/starter_templates/go/code/app/main.go
@@ -33,6 +33,6 @@ func main() {
 	// if len(fileContents) > 0 {
 	// 	panic("Scanner not implemented")
 	// } else {
-	// 	fmt.Println("EOF  null") // Placeholder, remove this line when implementing the scanner
+	// 	fmt.Println("EOF  null") // Placeholder, replace this line when implementing the scanner
 	// }
 }

--- a/starter_templates/java/code/src/main/java/Main.java
+++ b/starter_templates/java/code/src/main/java/Main.java
@@ -33,7 +33,7 @@ public class Main {
     // if (fileContents.length() > 0) {
     //   throw new RuntimeException("Scanner not implemented");
     // } else {
-    //   System.out.println("EOF  null"); // Placeholder, remove this line when implementing the scanner
+    //   System.out.println("EOF  null"); // Placeholder, replace this line when implementing the scanner
     // }
   }
 }

--- a/starter_templates/kotlin/code/src/main/kotlin/Main.kt
+++ b/starter_templates/kotlin/code/src/main/kotlin/Main.kt
@@ -24,6 +24,6 @@ fun main(args: Array<String>) {
     // if (fileContents.isNotEmpty()) {
     //     throw NotImplementedError("Scanner not implemented")
     // } else {
-    //     println("EOF  null") // Placeholder, remove this line when implementing the scanner
+    //     println("EOF  null") // Placeholder, replace this line when implementing the scanner
     // }
 }

--- a/starter_templates/ocaml/code/src/main.ml
+++ b/starter_templates/ocaml/code/src/main.ml
@@ -20,5 +20,5 @@ let () =
     failwith "Scanner not implemented"
   else
     (* Uncomment this block to pass the first stage *)
-    (* print_endline "EOF  null"; (* Placeholder, remove this line when implementing the scanner *) *)
+    (* print_endline "EOF  null"; (* Placeholder, replace this line when implementing the scanner *) *)
     ()

--- a/starter_templates/php/code/app/main.php
+++ b/starter_templates/php/code/app/main.php
@@ -23,5 +23,5 @@ fwrite(STDERR, "Logs from your program will appear here!\n");
 // if ($file_contents) {
 //     throw new Exception("Scanner not implemented");
 // } else {
-//     echo "EOF  null\n"; // Placeholder, remove this line when implementing the scanner
+//     echo "EOF  null\n"; // Placeholder, replace this line when implementing the scanner
 // }

--- a/starter_templates/python/code/app/main.py
+++ b/starter_templates/python/code/app/main.py
@@ -23,7 +23,7 @@ def main():
     # if file_contents:
     #     raise NotImplementedError("Scanner not implemented")
     # else:
-    #     print("EOF  null") # Placeholder, remove this line when implementing the scanner
+    #     print("EOF  null") # Placeholder, replace this line when implementing the scanner
 
 
 if __name__ == "__main__":

--- a/starter_templates/rust/code/src/main.rs
+++ b/starter_templates/rust/code/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
             // if !file_contents.is_empty() {
             //     panic!("Scanner not implemented");
             // } else {
-            //     println!("EOF  null"); // Placeholder, remove this line when implementing the scanner
+            //     println!("EOF  null"); // Placeholder, replace this line when implementing the scanner
             // }
         }
         _ => {

--- a/starter_templates/zig/code/src/main.zig
+++ b/starter_templates/zig/code/src/main.zig
@@ -27,6 +27,6 @@ pub fn main() !void {
     // if (file_contents.len > 0) {
     //     @panic("Scanner not implemented");
     // } else {
-    //     try std.io.getStdOut().writer().print("EOF  null\n", .{}); // Placeholder, remove this line when implementing the scanner
+    //     try std.io.getStdOut().writer().print("EOF  null\n", .{}); // Placeholder, replace this line when implementing the scanner
     // }
 }


### PR DESCRIPTION
Apparently, "remove" could be interpreted differently than we intended:

<img width="972" alt="image" src="https://github.com/user-attachments/assets/8faa0e6f-ebb3-4f7d-ae59-6dabd1624292" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated comments across all supported languages to clarify that placeholder lines should be replaced (not removed) when implementing the scanner.

- **Style**
  - Improved comment wording and minor whitespace adjustments for clearer instructional guidance.

- **Refactor**
  - Activated previously commented-out placeholder logic in solution files for multiple languages, making placeholder behavior consistently active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->