### PR TITLE
F-13813: Clarify exit codes for compilation and runtime errors

### DIFF
--- a/stage_descriptions/classes-06-dg2.md
+++ b/stage_descriptions/classes-06-dg2.md
@@ -80,7 +80,7 @@ Undefined property 'feeling'.
 [line 5]
 ```
 
-The tester will assert that for valid usages of this, the exit code should be 0. For invalid returns, the program should exit with code 65 (compile error) and print an appropriate error message.
+The tester will assert that for valid usages of this, the exit code should be 0. For compilation errors, the program should exit with code 65. For runtime errors, the program should exit with code 70. Both errors should print an appropriate error message.
 
 ### Notes
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the expected exit codes and error messages for valid usage, compilation errors, and runtime errors when validating the use of the `this` keyword.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->