### PR TITLE
Use gradle distTar in Kotlin compile.sh

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,3 +12,10 @@ concurrency:
 jobs:
   test_course_definition:
     uses: codecrafters-io/course-sdk/.github/workflows/test-course-definition.yml@main
+    with:
+      sdkRef: main
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+    secrets: inherit

--- a/compiled_starters/kotlin/.codecrafters/compile.sh
+++ b/compiled_starters/kotlin/.codecrafters/compile.sh
@@ -8,7 +8,7 @@
 
 set -e # Exit on failure
 
-gradle build
+gradle distTar
 cd /tmp/codecrafters-build-interpreter-kotlin/distributions
 rm -rf app
 tar -xvf app.tar

--- a/compiled_starters/kotlin/your_program.sh
+++ b/compiled_starters/kotlin/your_program.sh
@@ -14,7 +14,7 @@ set -e # Exit early if any commands fail
 # - Edit .codecrafters/compile.sh to change how your program compiles remotely
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
-  gradle build
+  gradle distTar
   cd /tmp/codecrafters-build-interpreter-kotlin/distributions
   rm -rf app
   tar -xvf app.tar

--- a/dockerfiles/go-1.22.Dockerfile
+++ b/dockerfiles/go-1.22.Dockerfile
@@ -11,6 +11,7 @@ COPY --exclude=.git --exclude=README.md . /app
 
 # Starting from Go 1.20, the go standard library is no loger compiled.
 # Setting GODEBUG to "installgoroot=all" restores the old behavior
+# hadolint ignore=DL3062
 RUN GODEBUG="installgoroot=all" go install std
 
 RUN go mod download

--- a/dockerfiles/go-1.24.Dockerfile
+++ b/dockerfiles/go-1.24.Dockerfile
@@ -11,6 +11,7 @@ COPY --exclude=.git --exclude=README.md . /app
 
 # Starting from Go 1.20, the go standard library is no loger compiled.
 # Setting GODEBUG to "installgoroot=all" restores the old behavior
+# hadolint ignore=DL3062
 RUN GODEBUG="installgoroot=all" go install std
 
 RUN go mod download

--- a/solutions/kotlin/01-ry8/code/.codecrafters/compile.sh
+++ b/solutions/kotlin/01-ry8/code/.codecrafters/compile.sh
@@ -8,7 +8,7 @@
 
 set -e # Exit on failure
 
-gradle build
+gradle distTar
 cd /tmp/codecrafters-build-interpreter-kotlin/distributions
 rm -rf app
 tar -xvf app.tar

--- a/solutions/kotlin/01-ry8/code/your_program.sh
+++ b/solutions/kotlin/01-ry8/code/your_program.sh
@@ -14,7 +14,7 @@ set -e # Exit early if any commands fail
 # - Edit .codecrafters/compile.sh to change how your program compiles remotely
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
-  gradle build
+  gradle distTar
   cd /tmp/codecrafters-build-interpreter-kotlin/distributions
   rm -rf app
   tar -xvf app.tar

--- a/starter_templates/kotlin/code/.codecrafters/compile.sh
+++ b/starter_templates/kotlin/code/.codecrafters/compile.sh
@@ -8,7 +8,7 @@
 
 set -e # Exit on failure
 
-gradle build
+gradle distTar
 cd /tmp/codecrafters-build-interpreter-kotlin/distributions
 rm -rf app
 tar -xvf app.tar


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches Kotlin build step to distTar, updates the test workflow with inputs/permissions, and adds hadolint ignore to Go Dockerfiles.
> 
> - **Build (Kotlin)**:
>   - Replace `gradle build` with `gradle distTar` in `compiled_starters/kotlin/.codecrafters/compile.sh`, `solutions/kotlin/01-ry8/code/.codecrafters/compile.sh`, `starter_templates/kotlin/code/.codecrafters/compile.sh`, and corresponding `your_program.sh`.
> - **CI**:
>   - Update `.github/workflows/test.yml` job `test_course_definition` with `with: sdkRef=main`, `permissions` (contents: read, checks: write, pull-requests: write), and `secrets: inherit`.
> - **Docker**:
>   - Add `# hadolint ignore=DL3062` before `RUN GODEBUG="installgoroot=all" go install std` in `dockerfiles/go-1.22.Dockerfile` and `dockerfiles/go-1.24.Dockerfile`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2b9d8b35d273764250f1979cba488ce99b1029d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->