### PR TITLE
CC-2203: Upgrade Odin to dev-2026-04

### DIFF
--- a/compiled_starters/odin/README.md
+++ b/compiled_starters/odin/README.md
@@ -43,7 +43,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `odin` installed locally
+1. Ensure you have `odin (dev-2026-04)` installed locally
 2. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.odin`.
 3. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/odin/codecrafters.yml
+++ b/compiled_starters/odin/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Odin version used to run your code
 # on Codecrafters.
 #
-# Available versions: odin-2025.7
-buildpack: odin-2025.7
+# Available versions: odin-2026.4
+buildpack: odin-2026.4

--- a/compiled_starters/odin/src/main.odin
+++ b/compiled_starters/odin/src/main.odin
@@ -18,11 +18,12 @@ main :: proc() {
         os.exit(1)
     }
 
-    file_contents, ok := os.read_entire_file(filename)
-    if !ok {
+    file_contents, err := os.read_entire_file(filename, context.allocator)
+    if err != nil {
         fmt.eprintf("Failed to read file: %s\n", filename)
         os.exit(1)
     }
+    defer delete(file_contents, context.allocator)
 
     // You can use print statements as follows for debugging, they'll be visible when running tests.
     fmt.eprintln("Logs from your program will appear here!")

--- a/dockerfiles/odin-2026.4.Dockerfile
+++ b/dockerfiles/odin-2026.4.Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM silkeh/clang:21-trixie
+
+WORKDIR /Odin-install
+RUN git clone --depth 1 -b dev-2026-04 https://github.com/odin-lang/Odin.git /Odin-install \
+    && git checkout dev-2026-04 \
+    && make
+
+RUN mkdir /opt/Odin \
+    && cp -R ./base ./core ./shared ./vendor ./odin /opt/Odin/
+
+WORKDIR /
+RUN rm -rf /Odin-install
+ENV PATH="/opt/Odin:${PATH}"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# Install language-specific dependencies
+RUN .codecrafters/compile.sh

--- a/solutions/odin/01-ry8/code/README.md
+++ b/solutions/odin/01-ry8/code/README.md
@@ -43,7 +43,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `odin` installed locally
+1. Ensure you have `odin (dev-2026-04)` installed locally
 2. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.odin`.
 3. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/odin/01-ry8/code/codecrafters.yml
+++ b/solutions/odin/01-ry8/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Odin version used to run your code
 # on Codecrafters.
 #
-# Available versions: odin-2025.7
-buildpack: odin-2025.7
+# Available versions: odin-2026.4
+buildpack: odin-2026.4

--- a/solutions/odin/01-ry8/code/src/main.odin
+++ b/solutions/odin/01-ry8/code/src/main.odin
@@ -18,11 +18,12 @@ main :: proc() {
         os.exit(1)
     }
 
-    file_contents, ok := os.read_entire_file(filename)
-    if !ok {
+    file_contents, err := os.read_entire_file(filename, context.allocator)
+    if err != nil {
         fmt.eprintf("Failed to read file: %s\n", filename)
         os.exit(1)
     }
+    defer delete(file_contents, context.allocator)
 
     if len(file_contents) > 0 {
         panic("Scanner not implemented")

--- a/solutions/odin/01-ry8/diff/src/main.odin.diff
+++ b/solutions/odin/01-ry8/diff/src/main.odin.diff
@@ -1,5 +1,4 @@
-@@ -2,35 +2,31 @@
-
+@@ -3,35 +3,31 @@
  import "core:os"
  import "core:fmt"
  import "core:strings"
@@ -18,11 +17,12 @@
          os.exit(1)
      }
 
-     file_contents, ok := os.read_entire_file(filename)
-     if !ok {
+     file_contents, err := os.read_entire_file(filename, context.allocator)
+     if err != nil {
          fmt.eprintf("Failed to read file: %s\n", filename)
          os.exit(1)
      }
+     defer delete(file_contents, context.allocator)
 
 -    // You can use print statements as follows for debugging, they'll be visible when running tests.
 -    fmt.eprintln("Logs from your program will appear here!")

--- a/starter_templates/odin/code/src/main.odin
+++ b/starter_templates/odin/code/src/main.odin
@@ -18,11 +18,12 @@ main :: proc() {
         os.exit(1)
     }
 
-    file_contents, ok := os.read_entire_file(filename)
-    if !ok {
+    file_contents, err := os.read_entire_file(filename, context.allocator)
+    if err != nil {
         fmt.eprintf("Failed to read file: %s\n", filename)
         os.exit(1)
     }
+    defer delete(file_contents, context.allocator)
 
     // You can use print statements as follows for debugging, they'll be visible when running tests.
     fmt.eprintln("Logs from your program will appear here!")

--- a/starter_templates/odin/config.yml
+++ b/starter_templates/odin/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: odin
+  required_executable: odin (dev-2026-04)
   user_editable_file: src/main.odin


### PR DESCRIPTION
CC-2203: Upgrade Odin to dev-2026-03

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because this upgrades the language toolchain and runtime image, which can introduce build/runtime differences for all Odin submissions. Code changes are small but touch the compilation environment and core file I/O API usage.
> 
> **Overview**
> Upgrades the Odin track to **`odin-2026.4` (Odin `dev-2026-04`)** by updating `codecrafters.yml`, starter/solution READMEs, and `starter_templates/odin/config.yml`.
> 
> Adds a new `odin-2026.4` Dockerfile that builds Odin from the `dev-2026-04` branch, and updates starter/solution `main.odin` templates to the new `os.read_entire_file(filename, context.allocator)` signature with explicit error handling and `defer delete(...)` cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 437717b5c0ceae97d4bf8dc119f23ba49459e756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->