### PR TITLE
Fix typo in #ab0 title

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -680,7 +680,7 @@ stages:
 
   - slug: "ab0"
     primary_extension_slug: "inheritance"
-    name: "Inheritance errrors"
+    name: "Inheritance errors"
     difficulty: medium
     marketing_md: |-
       In this stage, you'll add validation for class inheritance, ensuring that class hierarchies are valid and providing clear error messages when they're not.


### PR DESCRIPTION
Thanks to @WashingtonARamos for highlighting the issue!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Updates a single display string in `course-definition.yml` (stage `ab0`) with no code or behavior changes, so risk is minimal.
> 
> **Overview**
> Fixes a typo in the `course-definition.yml` stage title for `ab0`, changing **"Inheritance errrors"** to **"Inheritance errors"**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abeba54bb884830dbed5ef99cf7c389489305e7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->