### PR TITLE
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

### DIFF
--- a/compiled_starters/c/README.md
+++ b/compiled_starters/c/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/main.c`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/clojure/README.md
+++ b/compiled_starters/clojure/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/interpreter/core.clj`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/cpp/README.md
+++ b/compiled_starters/cpp/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/main.cpp`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/csharp/README.md
+++ b/compiled_starters/csharp/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/main.cs`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/elixir/README.md
+++ b/compiled_starters/elixir/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `lib/main.ex`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/gleam/README.md
+++ b/compiled_starters/gleam/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/main.gleam`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/go/README.md
+++ b/compiled_starters/go/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `app/main.go`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/haskell/README.md
+++ b/compiled_starters/haskell/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `app/Main.hs`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/java/README.md
+++ b/compiled_starters/java/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/main/java/Main.java`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/javascript/README.md
+++ b/compiled_starters/javascript/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `app/main.js`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/kotlin/README.md
+++ b/compiled_starters/kotlin/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `app/src/main/kotlin/App.kt`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/ocaml/README.md
+++ b/compiled_starters/ocaml/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/main.ml`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/odin/README.md
+++ b/compiled_starters/odin/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/main.odin`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/php/README.md
+++ b/compiled_starters/php/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `app/main.php`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/python/README.md
+++ b/compiled_starters/python/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `app/main.py`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/ruby/README.md
+++ b/compiled_starters/ruby/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `app/main.rb`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/main.rs`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/scala/README.md
+++ b/compiled_starters/scala/README.md
@@ -31,11 +31,11 @@ challenge. This challenge will start from chapter 4,
 
 The entry point for your program is in
 `src/main/scala/codecrafters_interpreter/App.scala`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/swift/README.md
+++ b/compiled_starters/swift/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `Sources/main.swift`. Study and uncomment
-the relevant code, and push your changes to pass the first stage:
+the relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/typescript/README.md
+++ b/compiled_starters/typescript/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `app/main.ts`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/main.zig`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/c/01-ry8/code/README.md
+++ b/solutions/c/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/main.c`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/clojure/01-ry8/code/README.md
+++ b/solutions/clojure/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/interpreter/core.clj`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/cpp/01-ry8/code/README.md
+++ b/solutions/cpp/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/main.cpp`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/csharp/01-ry8/code/README.md
+++ b/solutions/csharp/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/main.cs`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/elixir/01-ry8/code/README.md
+++ b/solutions/elixir/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `lib/main.ex`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/gleam/01-ry8/code/README.md
+++ b/solutions/gleam/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/main.gleam`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/go/01-ry8/code/README.md
+++ b/solutions/go/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `app/main.go`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/haskell/01-ry8/code/README.md
+++ b/solutions/haskell/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `app/Main.hs`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/java/01-ry8/code/README.md
+++ b/solutions/java/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/main/java/Main.java`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/javascript/01-ry8/code/README.md
+++ b/solutions/javascript/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `app/main.js`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/kotlin/01-ry8/code/README.md
+++ b/solutions/kotlin/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `app/src/main/kotlin/App.kt`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/ocaml/01-ry8/code/README.md
+++ b/solutions/ocaml/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/main.ml`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/odin/01-ry8/code/README.md
+++ b/solutions/odin/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/main.odin`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/php/01-ry8/code/README.md
+++ b/solutions/php/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `app/main.php`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/python/01-ry8/code/README.md
+++ b/solutions/python/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `app/main.py`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/ruby/01-ry8/code/README.md
+++ b/solutions/ruby/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `app/main.rb`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/rust/01-ry8/code/README.md
+++ b/solutions/rust/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/main.rs`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/scala/01-ry8/code/README.md
+++ b/solutions/scala/01-ry8/code/README.md
@@ -31,11 +31,11 @@ challenge. This challenge will start from chapter 4,
 
 The entry point for your program is in
 `src/main/scala/codecrafters_interpreter/App.scala`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/swift/01-ry8/code/README.md
+++ b/solutions/swift/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `Sources/main.swift`. Study and uncomment
-the relevant code, and push your changes to pass the first stage:
+the relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/typescript/01-ry8/code/README.md
+++ b/solutions/typescript/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `app/main.ts`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/zig/01-ry8/code/README.md
+++ b/solutions/zig/01-ry8/code/README.md
@@ -30,11 +30,11 @@ challenge. This challenge will start from chapter 4,
 # Passing the first stage
 
 The entry point for your program is in `src/main.zig`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/starter_templates/all/code/README.md
+++ b/starter_templates/all/code/README.md
@@ -23,11 +23,10 @@ from chapter 4, [Scanning](https://craftinginterpreters.com/scanning.html).
 # Passing the first stage
 
 The entry point for your program is in `{{ user_editable_file }}`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!


### PR DESCRIPTION
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that update submission instructions; no runtime or build behavior is affected.
> 
> **Overview**
> Updates the “Passing the first stage” instructions across all compiled starter and solution READMEs (and the shared `starter_templates/all/code/README.md`) to **stop telling users to `git commit`/`git push`** and instead instruct them to run `codecrafters submit` to execute tests on CodeCrafters’ servers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c012d0ea1e2e20d179857af738b488773663796d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->