### PR TITLE
CC-2274: Upgrade Gleam to v0.16

### DIFF
--- a/compiled_starters/gleam/.codecrafters/compile.sh
+++ b/compiled_starters/gleam/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/compiled_starters/gleam/.codecrafters/run.sh
+++ b/compiled_starters/gleam/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/compiled_starters/gleam/.gitignore
+++ b/compiled_starters/gleam/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/compiled_starters/gleam/codecrafters.yml
+++ b/compiled_starters/gleam/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.14
-buildpack: gleam-1.14
+# Available versions: gleam-1.16
+buildpack: gleam-1.16

--- a/compiled_starters/gleam/gleam.toml
+++ b/compiled_starters/gleam/gleam.toml
@@ -1,4 +1,4 @@
-name = "codecrafters_interpreter"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
@@ -7,8 +7,9 @@ version = "1.0.0"
 [dependencies]
 gleam_stdlib = "~> 0.34 or ~> 1.0"
 simplifile = ">= 2.0.1 and < 3.0.0"
-gleam_erlang = ">= 0.25.0 and < 1.0.0"
+gleam_erlang = ">= 1.3.0 and < 2.0.0"
 argv = ">= 1.0.2 and < 2.0.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/compiled_starters/gleam/manifest.toml
+++ b/compiled_starters/gleam/manifest.toml
@@ -2,17 +2,22 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
-  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
-  { name = "simplifile", version = "2.0.1", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "5FFEBD0CAB39BDD343C3E1CCA6438B2848847DC170BA2386DF9D7064F34DF000" },
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
 [requirements]
-argv = { version = ">= 1.0.2 and < 2.0.0"}
-gleam_erlang = { version = ">= 0.25.0 and < 1.0.0" }
+argv = { version = ">= 1.0.2 and < 2.0.0" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
 gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }
 simplifile = { version = ">= 2.0.1 and < 3.0.0" }

--- a/compiled_starters/gleam/your_program.sh
+++ b/compiled_starters/gleam/your_program.sh
@@ -15,10 +15,11 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   gleam build
+  gleam run -m gleescript
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/dockerfiles/gleam-1.16.Dockerfile
+++ b/dockerfiles/gleam-1.16.Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM ghcr.io/gleam-lang/gleam:v1.16.0-erlang-alpine
+
+# Rebuild if gleam.toml or manifest.toml change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="gleam.toml,manifest.toml"
+
+RUN apk add --no-cache \
+    build-base~=0.5
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# Force deps to be downloaded
+RUN gleam build
+
+# Cache build directory
+RUN mkdir -p /app-cached
+RUN mv build /app-cached/build

--- a/solutions/gleam/01-ry8/code/.codecrafters/compile.sh
+++ b/solutions/gleam/01-ry8/code/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/solutions/gleam/01-ry8/code/.codecrafters/run.sh
+++ b/solutions/gleam/01-ry8/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/solutions/gleam/01-ry8/code/.gitignore
+++ b/solutions/gleam/01-ry8/code/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/solutions/gleam/01-ry8/code/codecrafters.yml
+++ b/solutions/gleam/01-ry8/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.14
-buildpack: gleam-1.14
+# Available versions: gleam-1.16
+buildpack: gleam-1.16

--- a/solutions/gleam/01-ry8/code/gleam.toml
+++ b/solutions/gleam/01-ry8/code/gleam.toml
@@ -1,4 +1,4 @@
-name = "codecrafters_interpreter"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
@@ -7,8 +7,9 @@ version = "1.0.0"
 [dependencies]
 gleam_stdlib = "~> 0.34 or ~> 1.0"
 simplifile = ">= 2.0.1 and < 3.0.0"
-gleam_erlang = ">= 0.25.0 and < 1.0.0"
+gleam_erlang = ">= 1.3.0 and < 2.0.0"
 argv = ">= 1.0.2 and < 2.0.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/solutions/gleam/01-ry8/code/manifest.toml
+++ b/solutions/gleam/01-ry8/code/manifest.toml
@@ -2,17 +2,22 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
-  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
-  { name = "simplifile", version = "2.0.1", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "5FFEBD0CAB39BDD343C3E1CCA6438B2848847DC170BA2386DF9D7064F34DF000" },
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
 [requirements]
-argv = { version = ">= 1.0.2 and < 2.0.0"}
-gleam_erlang = { version = ">= 0.25.0 and < 1.0.0" }
+argv = { version = ">= 1.0.2 and < 2.0.0" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
 gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }
 simplifile = { version = ">= 2.0.1 and < 3.0.0" }

--- a/solutions/gleam/01-ry8/code/your_program.sh
+++ b/solutions/gleam/01-ry8/code/your_program.sh
@@ -15,10 +15,11 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   gleam build
+  gleam run -m gleescript
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/starter_templates/gleam/code/.codecrafters/compile.sh
+++ b/starter_templates/gleam/code/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/starter_templates/gleam/code/.codecrafters/run.sh
+++ b/starter_templates/gleam/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/starter_templates/gleam/code/.gitignore
+++ b/starter_templates/gleam/code/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/starter_templates/gleam/code/gleam.toml
+++ b/starter_templates/gleam/code/gleam.toml
@@ -1,4 +1,4 @@
-name = "codecrafters_interpreter"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
@@ -7,8 +7,9 @@ version = "1.0.0"
 [dependencies]
 gleam_stdlib = "~> 0.34 or ~> 1.0"
 simplifile = ">= 2.0.1 and < 3.0.0"
-gleam_erlang = ">= 0.25.0 and < 1.0.0"
+gleam_erlang = ">= 1.3.0 and < 2.0.0"
 argv = ">= 1.0.2 and < 2.0.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/starter_templates/gleam/code/manifest.toml
+++ b/starter_templates/gleam/code/manifest.toml
@@ -2,17 +2,22 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
-  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
-  { name = "simplifile", version = "2.0.1", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "5FFEBD0CAB39BDD343C3E1CCA6438B2848847DC170BA2386DF9D7064F34DF000" },
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
 [requirements]
-argv = { version = ">= 1.0.2 and < 2.0.0"}
-gleam_erlang = { version = ">= 0.25.0 and < 1.0.0" }
+argv = { version = ">= 1.0.2 and < 2.0.0" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
 gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }
 simplifile = { version = ">= 2.0.1 and < 3.0.0" }


### PR DESCRIPTION
CC-2274: Upgrade Gleam to v0.16

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the Gleam runtime/buildpack version, dependency set, and how Gleam projects are compiled/executed, which could break CI or CodeCrafters runner behavior if the generated `main` binary or `gleescript` step differs across environments.
> 
> **Overview**
> Upgrades the Gleam starters/solutions to use **Gleam `1.16`** (via `codecrafters.yml`) and refreshes Gleam dependencies/lockfiles (`gleam_erlang` 1.x, updated package versions, and adds dev dependency `gleescript`).
> 
> Changes the build/run flow to produce and execute a generated `main` binary: `.codecrafters/compile.sh` now runs `gleam run -m gleescript`, and `.codecrafters/run.sh` (and `your_program.sh`) now `exec` the local `./main` instead of running via `gleam run`; `main` is added to `.gitignore`.
> 
> Adds a new `dockerfiles/gleam-1.16.Dockerfile` to support the updated toolchain and cache dependencies/build artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2518612f125a5da90442e12197b4d0cf81aa2a57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->